### PR TITLE
Add browser selection feature in conftest.py

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,12 +10,17 @@ def setUp():
 
 
 @pytest.fixture(scope="class")
-def oneTimeSetUp(request):
-    base_url = "https://www.userlike.com/en/"
-    driver = webdriver.Chrome()
-    driver.maximize_window()
-    driver.get(base_url)
-    driver.implicitly_wait(3)
+def oneTimeSetUp(request, browser):
+    if browser == "chrome":
+        base_url = "https://www.userlike.com/en/"
+        driver = webdriver.Chrome()
+        driver.maximize_window()
+        driver.get(base_url)
+        driver.implicitly_wait(3)
+    else:
+        baseURL = "https://www.userlike.com/en/"
+        driver = webdriver.Firefox()
+        driver.get(baseURL)
 
     #if test class exist
     if request.cls is not None:
@@ -29,7 +34,14 @@ def oneTimeSetUp(request):
 def login(request, oneTimeSetUp):
     driver = oneTimeSetUp
     lp = LoginPage(driver)
-    lp.login("romin.parvardeh@gmail.com", "RominRomin!234!234")
+    lp.login("romin5954@gmail.com", "RominRomin!234!234")
     yield driver
 
 
+
+def pytest_addoption(parser):
+    parser.addoption("--browser")
+
+@pytest.fixture(scope="session")
+def browser(request):
+    return request.config.getoption("--browser")


### PR DESCRIPTION
This commit introduces the ability to specify the browser (Chrome or Firefox) when running tests using Pytest.

we can run the test on chrome like 
pytest --browser chrome 

and on firefox as : 
pytest --browser firefox 